### PR TITLE
refactor(settings): Replace all public arrow functions with standard functions

### DIFF
--- a/packages/settings/src/cf/index.ts
+++ b/packages/settings/src/cf/index.ts
@@ -9,7 +9,7 @@ const SETTINGS_COLLECTION = 'fl_settings'
 
 const factory: FlamelinkSettingsFactory = context => {
   const api: SettingsPublicApi = {
-    ref: document => {
+    ref(document) {
       const firestoreService = flamelink._ensureService('firestore', context)
 
       return document
@@ -19,13 +19,13 @@ const factory: FlamelinkSettingsFactory = context => {
       // .where('_fl_meta_.locale', '==', context.locale)
     },
 
-    getRaw: ({ document, ...options } = {}) => {
+    getRaw({ document, ...options } = {}) {
       return applyOptionsForCF(api.ref(document), options).get({
         source: options.source || 'default'
       })
     },
 
-    get: async ({ document, ...options } = {}) => {
+    async get({ document, ...options } = {}) {
       const pluckFields = pluckResultFields(options.fields)
       const snapshot = await api.getRaw({ document, ...options })
 
@@ -44,38 +44,49 @@ const factory: FlamelinkSettingsFactory = context => {
       return pluckFields(entries)
     },
 
-    setEnvironment: async env => {
+    async setEnvironment(env) {
       context.env = env
       return env
     },
 
-    getEnvironment: async () => context.env,
+    async getEnvironment() {
+      return context.env
+    },
 
     // TODO: Consider checking for supported locales - if we want - don't want to make API request
-    setLocale: async locale => {
+    async setLocale(locale) {
       context.locale = locale
       return locale
     },
 
-    getLocale: async () => context.locale,
+    async getLocale() {
+      return context.locale
+    },
 
-    getGlobals: async (options = {}) =>
-      api.get({
+    async getGlobals(options = {}) {
+      return api.get({
         ...options,
         document: 'globals'
-      }),
+      })
+    },
 
-    getImageSizes: async (options = {}) =>
-      api.get({ ...options, document: 'general', fields: ['imageSizes'] }),
+    async getImageSizes(options = {}) {
+      return api.get({
+        ...options,
+        document: 'general',
+        fields: ['imageSizes']
+      })
+    },
 
-    getDefaultPermissionsGroup: async (options = {}) =>
-      api.get({
+    async getDefaultPermissionsGroup(options = {}) {
+      return api.get({
         ...options,
         document: 'general',
         fields: ['defaultPermissionsGroup']
-      }),
+      })
+    },
 
-    subscribeRaw: ({ document, callback, ...options }) => {
+    subscribeRaw({ document, callback, ...options }) {
       const filtered = applyOptionsForCF(api.ref(document), options)
 
       return filtered.onSnapshot(
@@ -87,13 +98,13 @@ const factory: FlamelinkSettingsFactory = context => {
       )
     },
 
-    subscribe: ({ document, callback, changeType, ...options }) => {
+    subscribe({ document, callback, changeType, ...options }) {
       const pluckFields = pluckResultFields(options.fields)
 
       return api.subscribeRaw({
         document,
         ...options,
-        callback: async (err, snapshot) => {
+        async callback(err, snapshot) {
           if (err) {
             return callback(err, null)
           }
@@ -128,22 +139,25 @@ const factory: FlamelinkSettingsFactory = context => {
       })
     },
 
-    subscribeGlobals: options =>
-      api.subscribe({ ...options, document: 'globals' }),
+    subscribeGlobals(options) {
+      return api.subscribe({ ...options, document: 'globals' })
+    },
 
-    subscribeImageSizes: options =>
-      api.subscribe({
+    subscribeImageSizes(options) {
+      return api.subscribe({
         ...options,
         document: 'general',
         fields: ['imageSizes']
-      }),
+      })
+    },
 
-    subscribeDefaultPermissionsGroup: options =>
-      api.subscribe({
+    subscribeDefaultPermissionsGroup(options) {
+      return api.subscribe({
         ...options,
         document: 'general',
         fields: ['defaultPermissionsGroup']
       })
+    }
   }
 
   return api

--- a/packages/settings/src/rtdb/index.ts
+++ b/packages/settings/src/rtdb/index.ts
@@ -9,18 +9,18 @@ import { getSettingsRefPath } from './helpers'
 
 const factory: FlamelinkSettingsFactory = context => {
   const api: SettingsPublicApi = {
-    ref: ref => {
+    ref(ref) {
       const dbService = flamelink._ensureService('database', context)
       return dbService.ref(getSettingsRefPath(ref))
     },
 
-    getRaw: ({ settingsKey, ...options }) => {
+    getRaw({ settingsKey, ...options }) {
       return applyOptionsForRTDB(api.ref(settingsKey), options).once(
         options.event || 'value'
       )
     },
 
-    get: async ({ settingsKey, ...options }) => {
+    async get({ settingsKey, ...options }) {
       const pluckFields = pluckResultFields(options.fields)
       const snapshot = await api.getRaw({ settingsKey, ...options })
       const value =
@@ -31,34 +31,41 @@ const factory: FlamelinkSettingsFactory = context => {
       return options.needsWrap ? result[settingsKey] : result
     },
 
-    setEnvironment: async env => {
+    async setEnvironment(env) {
       context.env = env
       return env
     },
 
-    getEnvironment: async () => context.env,
+    async getEnvironment() {
+      return context.env
+    },
 
     // TODO: Consider checking for supported locales - if we want - don't want to make API request
-    setLocale: async locale => {
+    async setLocale(locale) {
       context.locale = locale
       return locale
     },
 
-    getLocale: async () => context.locale,
+    async getLocale() {
+      return context.locale
+    },
 
-    getGlobals: async (options = {}) =>
-      api.get({ ...options, needsWrap: true, settingsKey: 'globals' }),
+    async getGlobals(options = {}) {
+      return api.get({ ...options, needsWrap: true, settingsKey: 'globals' })
+    },
 
-    getImageSizes: async (options = {}) =>
-      api.get({ ...options, settingsKey: 'general/imageSizes' }),
+    async getImageSizes(options = {}) {
+      return api.get({ ...options, settingsKey: 'general/imageSizes' })
+    },
 
-    getDefaultPermissionsGroup: async (options = {}) =>
-      api.get({
+    async getDefaultPermissionsGroup(options = {}) {
+      return api.get({
         ...options,
         settingsKey: 'general/defaultPermissionsGroup'
-      }),
+      })
+    },
 
-    subscribeRaw: ({ settingsKey, callback, ...options }) => {
+    subscribeRaw({ settingsKey, callback, ...options }) {
       const filteredRef = applyOptionsForRTDB(api.ref(settingsKey), options)
 
       filteredRef.on(
@@ -72,13 +79,13 @@ const factory: FlamelinkSettingsFactory = context => {
       return unsubscribe
     },
 
-    subscribe: ({ settingsKey, callback, ...options }) => {
+    subscribe({ settingsKey, callback, ...options }) {
       const pluckFields = pluckResultFields(options.fields)
 
       return api.subscribeRaw({
         settingsKey,
         ...options,
-        callback: async (err, snapshot) => {
+        async callback(err, snapshot) {
           if (err) {
             return callback(err, null)
           }
@@ -97,17 +104,20 @@ const factory: FlamelinkSettingsFactory = context => {
       })
     },
 
-    subscribeGlobals: options =>
-      api.subscribe({ ...options, settingsKey: 'globals' }),
+    subscribeGlobals(options) {
+      return api.subscribe({ ...options, settingsKey: 'globals' })
+    },
 
-    subscribeImageSizes: options =>
-      api.subscribe({ ...options, settingsKey: 'general/imageSizes' }),
+    subscribeImageSizes(options) {
+      return api.subscribe({ ...options, settingsKey: 'general/imageSizes' })
+    },
 
-    subscribeDefaultPermissionsGroup: options =>
-      api.subscribe({
+    subscribeDefaultPermissionsGroup(options) {
+      return api.subscribe({
         ...options,
         settingsKey: 'general/defaultPermissionsGroup'
       })
+    }
   }
 
   return api


### PR DESCRIPTION
Minor refactor to get around Rollup's weird arguments context sharing bug