### PR TITLE
fix(types): update types to not use default import syntax

### DIFF
--- a/packages/app/src/constants.ts
+++ b/packages/app/src/constants.ts
@@ -1,4 +1,4 @@
-import App from '@flamelink/sdk-app-types'
+import * as App from '@flamelink/sdk-app-types'
 
 export const PUBLIC_MODULES: App.ModuleName[] = [
   'content',

--- a/packages/app/src/helpers.ts
+++ b/packages/app/src/helpers.ts
@@ -1,4 +1,4 @@
-import App from '@flamelink/sdk-app-types'
+import * as App from '@flamelink/sdk-app-types'
 import { logError } from '@flamelink/sdk-utils'
 import get from 'lodash/get'
 

--- a/packages/app/src/index.ts
+++ b/packages/app/src/index.ts
@@ -1,4 +1,4 @@
-import App from '@flamelink/sdk-app-types'
+import * as App from '@flamelink/sdk-app-types'
 import { logWarning, logError } from '@flamelink/sdk-utils'
 import {
   getModule,

--- a/packages/content-types/index.d.ts
+++ b/packages/content-types/index.d.ts
@@ -1,4 +1,4 @@
-import App from '@flamelink/sdk-app-types'
+import * as App from '@flamelink/sdk-app-types'
 
 // eslint-disable-next-line no-redeclare
 declare namespace Content {

--- a/packages/content/src/cf/__tests__/index.test.ts
+++ b/packages/content/src/cf/__tests__/index.test.ts
@@ -1,6 +1,6 @@
 import { Context } from '@flamelink/sdk-app-types'
 import { FirebaseApp } from '@firebase/app-types'
-import Content from '@flamelink/sdk-content-types'
+import * as Content from '@flamelink/sdk-content-types'
 import {
   initializeFirestoreProject,
   getBaseContext

--- a/packages/content/src/index.ts
+++ b/packages/content/src/index.ts
@@ -1,5 +1,5 @@
 import flamelink from '@flamelink/sdk-app'
-import App from '@flamelink/sdk-app-types'
+import * as App from '@flamelink/sdk-app-types'
 import { getDefaultImport } from '@flamelink/sdk-utils'
 import '@flamelink/sdk-schemas'
 

--- a/packages/content/src/rtdb/index.ts
+++ b/packages/content/src/rtdb/index.ts
@@ -2,7 +2,7 @@ import get from 'lodash/get'
 import keys from 'lodash/keys'
 import compose from 'compose-then'
 import flamelink from '@flamelink/sdk-app'
-import App from '@flamelink/sdk-app-types'
+import * as App from '@flamelink/sdk-app-types'
 import { FlamelinkFactory, Api, RTDB } from '@flamelink/sdk-content-types'
 import {
   applyOptionsForRTDB,

--- a/packages/flamelink/content/index.cdn.ts
+++ b/packages/flamelink/content/index.cdn.ts
@@ -9,7 +9,7 @@
  */
 
 import flamelink from '@flamelink/sdk-app'
-import App from '@flamelink/sdk-app-types'
+import * as App from '@flamelink/sdk-app-types'
 
 const content: App.SetupModule = async (context: App.Context) => {
   if (context.dbType === 'rtdb') {

--- a/packages/flamelink/navigation/index.cdn.ts
+++ b/packages/flamelink/navigation/index.cdn.ts
@@ -9,7 +9,7 @@
  */
 
 import flamelink from '@flamelink/sdk-app'
-import App from '@flamelink/sdk-app-types'
+import * as App from '@flamelink/sdk-app-types'
 
 const navigation: App.SetupModule = async (context: App.Context) => {
   if (context.dbType === 'rtdb') {

--- a/packages/flamelink/public.d.ts
+++ b/packages/flamelink/public.d.ts
@@ -2,19 +2,19 @@
 // Project: flamelink-js-sdk
 // Definitions by: JP Erasmus <jp@flamelink.io>
 
-import App from '@flamelink/sdk-app-types'
-import Content from '@flamelink/sdk-content-types'
-import Schemas from '@flamelink/sdk-schemas-types'
-import Storage from '@flamelink/sdk-storage-types'
-import Navigation from '@flamelink/sdk-navigation-types'
-import Settings from '@flamelink/sdk-settings-types'
-import Users from '@flamelink/sdk-users-types'
+import * as AppTypes from '@flamelink/sdk-app-types'
+import * as Content from '@flamelink/sdk-content-types'
+import * as Schemas from '@flamelink/sdk-schemas-types'
+import * as Storage from '@flamelink/sdk-storage-types'
+import * as Navigation from '@flamelink/sdk-navigation-types'
+import * as Settings from '@flamelink/sdk-settings-types'
+import * as Users from '@flamelink/sdk-users-types'
 
 declare function flamelink(config: flamelink.Config): flamelink.App
 
 // eslint-disable-next-line no-redeclare
 declare namespace flamelink {
-  export type Config = App.Config
+  export type Config = AppTypes.Config
 
   export interface App {
     content: Content.Api
@@ -24,8 +24,6 @@ declare namespace flamelink {
     settings: Settings.Api
     users: Users.Api
   }
-
-  // export const version: string
 }
 
 // Global export outside of module loader environment

--- a/packages/flamelink/schemas/index.cdn.ts
+++ b/packages/flamelink/schemas/index.cdn.ts
@@ -9,7 +9,7 @@
  */
 
 import flamelink from '@flamelink/sdk-app'
-import App from '@flamelink/sdk-app-types'
+import * as App from '@flamelink/sdk-app-types'
 
 const schemas: App.SetupModule = async (context: App.Context) => {
   if (context.dbType === 'rtdb') {

--- a/packages/flamelink/settings/index.cdn.ts
+++ b/packages/flamelink/settings/index.cdn.ts
@@ -9,7 +9,7 @@
  */
 
 import flamelink from '@flamelink/sdk-app'
-import App from '@flamelink/sdk-app-types'
+import * as App from '@flamelink/sdk-app-types'
 
 const settings: App.SetupModule = async (context: App.Context) => {
   if (context.dbType === 'rtdb') {

--- a/packages/flamelink/storage/index.cdn.ts
+++ b/packages/flamelink/storage/index.cdn.ts
@@ -9,7 +9,7 @@
  */
 
 import flamelink from '@flamelink/sdk-app'
-import App from '@flamelink/sdk-app-types'
+import * as App from '@flamelink/sdk-app-types'
 
 const storage: App.SetupModule = async (context: App.Context) => {
   if (context.dbType === 'rtdb') {

--- a/packages/flamelink/users/index.cdn.ts
+++ b/packages/flamelink/users/index.cdn.ts
@@ -9,7 +9,7 @@
  */
 
 import flamelink from '@flamelink/sdk-app'
-import App from '@flamelink/sdk-app-types'
+import * as App from '@flamelink/sdk-app-types'
 
 const users: App.SetupModule = async (context: App.Context) => {
   if (context.dbType === 'rtdb') {

--- a/packages/navigation-types/index.d.ts
+++ b/packages/navigation-types/index.d.ts
@@ -1,4 +1,4 @@
-import App from '@flamelink/sdk-app-types'
+import * as App from '@flamelink/sdk-app-types'
 
 // eslint-disable-next-line no-redeclare
 declare namespace Navigation {

--- a/packages/navigation/src/index.ts
+++ b/packages/navigation/src/index.ts
@@ -1,5 +1,5 @@
 import flamelink from '@flamelink/sdk-app'
-import App from '@flamelink/sdk-app-types'
+import * as App from '@flamelink/sdk-app-types'
 import { getDefaultImport } from '@flamelink/sdk-utils'
 
 const navigation: App.SetupModule = function(context) {

--- a/packages/navigation/src/rtdb/index.ts
+++ b/packages/navigation/src/rtdb/index.ts
@@ -2,7 +2,7 @@ import compose from 'compose-then'
 import keys from 'lodash/keys'
 import castArray from 'lodash/castArray'
 import flamelink from '@flamelink/sdk-app'
-import App from '@flamelink/sdk-app-types'
+import * as App from '@flamelink/sdk-app-types'
 import { FlamelinkFactory, Api, RTDB } from '@flamelink/sdk-navigation-types'
 import {
   applyOptionsForRTDB,

--- a/packages/schemas-types/index.d.ts
+++ b/packages/schemas-types/index.d.ts
@@ -1,4 +1,4 @@
-import App from '@flamelink/sdk-app-types'
+import * as App from '@flamelink/sdk-app-types'
 
 // eslint-disable-next-line no-redeclare
 declare namespace Schemas {

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -1,5 +1,5 @@
 import flamelink from '@flamelink/sdk-app'
-import App from '@flamelink/sdk-app-types'
+import * as App from '@flamelink/sdk-app-types'
 import { getDefaultImport } from '@flamelink/sdk-utils'
 
 const schemas: App.SetupModule = function(context) {

--- a/packages/schemas/src/rtdb/index.ts
+++ b/packages/schemas/src/rtdb/index.ts
@@ -3,7 +3,7 @@ import set from 'lodash/set'
 import keys from 'lodash/keys'
 import castArray from 'lodash/castArray'
 import flamelink from '@flamelink/sdk-app'
-import App from '@flamelink/sdk-app-types'
+import * as App from '@flamelink/sdk-app-types'
 import { FlamelinkFactory, Api, RTDB } from '@flamelink/sdk-schemas-types'
 import {
   applyOptionsForRTDB,

--- a/packages/settings-types/index.d.ts
+++ b/packages/settings-types/index.d.ts
@@ -1,4 +1,4 @@
-import App from '@flamelink/sdk-app-types'
+import * as App from '@flamelink/sdk-app-types'
 
 // eslint-disable-next-line no-redeclare
 declare namespace Settings {

--- a/packages/settings/src/index.ts
+++ b/packages/settings/src/index.ts
@@ -1,5 +1,5 @@
 import flamelink from '@flamelink/sdk-app'
-import App from '@flamelink/sdk-app-types'
+import * as App from '@flamelink/sdk-app-types'
 import { getDefaultImport } from '@flamelink/sdk-utils'
 
 const settings: App.SetupModule = function(context) {

--- a/packages/settings/src/rtdb/index.ts
+++ b/packages/settings/src/rtdb/index.ts
@@ -1,5 +1,5 @@
 import flamelink from '@flamelink/sdk-app'
-import App from '@flamelink/sdk-app-types'
+import * as App from '@flamelink/sdk-app-types'
 import { FlamelinkFactory, Api, RTDB } from '@flamelink/sdk-settings-types'
 import {
   applyOptionsForRTDB,

--- a/packages/storage-types/index.d.ts
+++ b/packages/storage-types/index.d.ts
@@ -1,4 +1,4 @@
-import App from '@flamelink/sdk-app-types'
+import * as App from '@flamelink/sdk-app-types'
 
 // eslint-disable-next-line no-redeclare
 declare namespace Storage {

--- a/packages/storage/src/cf/index.ts
+++ b/packages/storage/src/cf/index.ts
@@ -6,7 +6,7 @@ import set from 'lodash/set'
 import values from 'lodash/values'
 import resizeImage from 'browser-image-resizer'
 import flamelink from '@flamelink/sdk-app'
-import App from '@flamelink/sdk-app-types'
+import * as App from '@flamelink/sdk-app-types'
 import {
   FlamelinkFactory,
   Api,

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -1,5 +1,5 @@
 import flamelink from '@flamelink/sdk-app'
-import App from '@flamelink/sdk-app-types'
+import * as App from '@flamelink/sdk-app-types'
 import { getDefaultImport } from '@flamelink/sdk-utils'
 
 const storage: App.SetupModule = function(context) {

--- a/packages/storage/src/rtdb/index.ts
+++ b/packages/storage/src/rtdb/index.ts
@@ -6,7 +6,7 @@ import get from 'lodash/get'
 import set from 'lodash/set'
 import resizeImage from 'browser-image-resizer'
 import flamelink from '@flamelink/sdk-app'
-import App from '@flamelink/sdk-app-types'
+import * as App from '@flamelink/sdk-app-types'
 import {
   FlamelinkFactory,
   Api,

--- a/packages/users-types/index.d.ts
+++ b/packages/users-types/index.d.ts
@@ -1,4 +1,4 @@
-import App from '@flamelink/sdk-app-types'
+import * as App from '@flamelink/sdk-app-types'
 
 // eslint-disable-next-line no-redeclare
 declare namespace Users {

--- a/packages/users/src/index.ts
+++ b/packages/users/src/index.ts
@@ -1,5 +1,5 @@
 import flamelink from '@flamelink/sdk-app'
-import App from '@flamelink/sdk-app-types'
+import * as App from '@flamelink/sdk-app-types'
 import { getDefaultImport } from '@flamelink/sdk-utils'
 
 const users: App.SetupModule = function(context) {

--- a/packages/users/src/rtdb/index.ts
+++ b/packages/users/src/rtdb/index.ts
@@ -1,6 +1,6 @@
 import compose from 'compose-then'
 import flamelink from '@flamelink/sdk-app'
-import App from '@flamelink/sdk-app-types'
+import * as App from '@flamelink/sdk-app-types'
 import { FlamelinkFactory, Api, RTDB } from '@flamelink/sdk-users-types'
 import {
   applyOptionsForRTDB,

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -10,7 +10,7 @@ import isPlainObject from 'lodash/isPlainObject'
 import memoize from 'lodash/memoize'
 import pick from 'lodash/fp/pick'
 import compose from 'compose-then'
-import App from '@flamelink/sdk-app-types'
+import * as App from '@flamelink/sdk-app-types'
 
 interface Memo {
   prepPopulateFields?(args: any): any


### PR DESCRIPTION
It seems like the default import syntax is throwing errors when used in
some Angular setups.