### PR TITLE
docs: fix variable reference in content

### DIFF
--- a/docs/content.md
+++ b/docs/content.md
@@ -15,7 +15,7 @@ This method does not _watch_ for real-time db changes, but is intended to retrie
 _To get all entries for a specific content type:_
 
 ```javascript
-const blogPost = await app.content.get({ schemaKey: 'blogPosts' })
+const blogPosts = await app.content.get({ schemaKey: 'blogPosts' })
 console.log('All the blog posts:', blogPosts)
 ```
 


### PR DESCRIPTION
### Summary

Fixes an undefined variable reference `blogPosts` in the "_To get all entries for a specific content type:_" example  code block in docs/content.md